### PR TITLE
🔥 Remove `abstractmethod`s from `Bo4eDataSet` that turned out to be not helpful

### DIFF
--- a/src/bomf/model/__init__.py
+++ b/src/bomf/model/__init__.py
@@ -65,19 +65,6 @@ class Bo4eDataSet(ABC):
     def __init__(self):
         self._uuid = uuid.uuid4()
 
-    @abstractmethod
-    def get_relations(self) -> Iterable[BusinessObjectRelation]:
-        """
-        returns all relations between the business objects
-        """
-
-    @abstractmethod
-    def get_business_object(self, bo_type: Type[Bo4eTyp], specification: Optional[str] = None) -> Bo4eTyp:
-        """
-        Returns a business object of the provided type from the collection.
-        If the type alone is not unique, you can provide an additional specification.
-        """
-
     def get_id(self) -> str:
         """
         returns a unique id that only this dataset uses.

--- a/unittests/test_bo4e_data_set.py
+++ b/unittests/test_bo4e_data_set.py
@@ -41,7 +41,7 @@ class _ExampleDataSet(Bo4eDataSet):
 
 class TestBo4eDataSet:
     async def test_example_data_set(self):
-        dataset: Bo4eDataSet = _ExampleDataSet()
+        dataset: _ExampleDataSet = _ExampleDataSet()
         assert len(list(dataset.get_relations())) == 1
         assert isinstance(dataset.get_business_object(Geschaeftspartner), Geschaeftspartner)
         assert isinstance(dataset.get_business_object(Adresse), Adresse)


### PR DESCRIPTION
Enforcing inheriting classes to instantiate methods that don't provide "Mehrwert" was a bad idea ;)