### PR TITLE
Create Error IDs on the fly

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,3 +3,4 @@ bo4e
 pydantic
 typeguard
 frozendict
+bidict

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 attrs==22.2.0
     # via -r requirements.in
+bidict==0.22.1
+    # via -r requirements.in
 bo4e==0.4.7
     # via -r requirements.in
 frozendict==2.3.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     pydantic
     typeguard
     frozendict
+    bidict
 # write here line by line the dependencies for your package
 
 [options.packages.find]

--- a/src/bomf/validation/core.py
+++ b/src/bomf/validation/core.py
@@ -95,7 +95,7 @@ def _generate_new_id(identifier: _IdentifierType, last_id: Optional[_IDType] = N
 
 def _get_error_id(identifier: _IdentifierType) -> _IDType:
     """
-    Returns a unique UUID for the provided identifier.
+    Returns a unique ID for the provided identifier.
     """
     if identifier not in _ERROR_ID_MAP:
         new_error_id = None

--- a/src/bomf/validation/core.py
+++ b/src/bomf/validation/core.py
@@ -121,7 +121,6 @@ class ValidationError(RuntimeError):
         validator_set: "ValidatorSet",
         error_id: _IDType,
     ):
-        # exc_id = _get_error_id(_get_identifier(cause)) if custom_error_id is None else custom_error_id
         formatted_param_infos = format_parameter_infos(
             validator[1], validator_set.field_validators[validator].param_infos, start_indent="\t\t"
         )

--- a/src/bomf/validation/core.py
+++ b/src/bomf/validation/core.py
@@ -453,7 +453,7 @@ class ValidatorSet(Generic[DataSetT]):
         for validator in self.field_validators:
             try:
                 coroutines[validator] = self._fill_params(validator, data_set)
-            except AttributeError or TypeError as error:
+            except (AttributeError, TypeError) as error:
                 await error_handler.catch(
                     f"Couldn't fill in parameter for validator function: {error}",
                     error,

--- a/unittests/test_validation.py
+++ b/unittests/test_validation.py
@@ -354,10 +354,14 @@ class TestValidation:
             await validator_set.validate(dataset_instance)
 
         sub_exceptions1: dict[_ValidatorMapInternIndexType, ValidationError] = {
-            exception.validator: exception for exception in error_group1.value.exceptions
+            exception.validator: exception
+            for exception in error_group1.value.exceptions
+            if type(exception) == ValidationError
         }
         sub_exceptions2: dict[_ValidatorMapInternIndexType, ValidationError] = {
-            exception.validator: exception for exception in error_group2.value.exceptions
+            exception.validator: exception
+            for exception in error_group2.value.exceptions
+            if type(exception) == ValidationError
         }
         assert len(sub_exceptions1) == 5
         # This is a self-consistency check to ensure that there is no unwanted randomness in the program.
@@ -366,9 +370,9 @@ class TestValidation:
         }
         # Different errors in the same function should get different error IDs.
         assert (
-            sub_exceptions1[check_different_fails, frozendict({"x": "x"})].id
-            != sub_exceptions1[check_different_fails, frozendict({"x": "z.x"})].id
+            sub_exceptions1[check_different_fails, frozendict({"x": "x"})].error_id
+            != sub_exceptions1[check_different_fails, frozendict({"x": "z.x"})].error_id
         )
         # This ensures that the ID is constant across python sessions - as long as the line number of the raising
         # exception in `check_fail` doesn't change.
-        assert sub_exceptions1[check_fail, frozendict({"x": "x"})].id == 47799448
+        assert sub_exceptions1[check_fail, frozendict({"x": "x"})].error_id == 47799448

--- a/unittests/test_validation.py
+++ b/unittests/test_validation.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Required
 
 from bomf import ValidatorSet
 from bomf.model import Bo4eDataSet
-from bomf.validation.core import ValidatorParamInfos, ValidatorType
+from bomf.validation.core import ValidationError, ValidatorParamInfos, ValidatorType, _ValidatorMapInternIndexType
 
 
 class Wrapper(BaseModel):
@@ -86,6 +86,13 @@ async def check_fail2(y: int) -> None:
 
 async def check_fail3(y: int) -> None:
     raise ValueError("This shouldn't be raised")
+
+
+async def check_different_fails(x: str):
+    if x == "Hello":
+        raise ValueError("Error 1")
+    else:
+        raise ValueError("Error 2")
 
 
 async def no_params():
@@ -332,3 +339,36 @@ class TestValidation:
         validator_set = ValidatorSet[DataSetTest]()
         validator_set.register(check_with_param_info, {"x": "x", "zz": "z.z"})
         await validator_set.validate(dataset_instance)
+
+    async def test_error_ids(self):
+        validator_set = ValidatorSet[DataSetTest]()
+        validator_set.register(check_fail, {"x": "x"})
+        validator_set.register(check_fail2, {"y": "y"})
+        validator_set.register(check_fail3, {"y": "y"}, depends_on=[check_fail])
+        validator_set.register(check_different_fails, {"x": "x"})
+        validator_set.register(check_different_fails, {"x": "z.x"})
+        with pytest.raises(ExceptionGroup) as error_group1:
+            await validator_set.validate(dataset_instance)
+        with pytest.raises(ExceptionGroup) as error_group2:
+            # This is just to ensure that the ID generation for the errors is not completely random and has consistency
+            await validator_set.validate(dataset_instance)
+
+        sub_exceptions1: dict[_ValidatorMapInternIndexType, ValidationError] = {
+            exception.validator: exception for exception in error_group1.value.exceptions
+        }
+        sub_exceptions2: dict[_ValidatorMapInternIndexType, ValidationError] = {
+            exception.validator: exception for exception in error_group2.value.exceptions
+        }
+        assert len(sub_exceptions1) == 5
+        # This is a self-consistency check to ensure that there is no unwanted randomness in the program.
+        assert {str(sub_exception1) for sub_exception1 in sub_exceptions1.values()} == {
+            str(sub_exception2) for sub_exception2 in sub_exceptions2.values()
+        }
+        # Different errors in the same function should get different error IDs.
+        assert (
+            sub_exceptions1[check_different_fails, frozendict({"x": "x"})].id
+            != sub_exceptions1[check_different_fails, frozendict({"x": "z.x"})].id
+        )
+        # This ensures that the ID is constant across python sessions - as long as the line number of the raising
+        # exception in `check_fail` doesn't change.
+        assert sub_exceptions1[check_fail, frozendict({"x": "x"})].id == 47799448

--- a/unittests/test_validation.py
+++ b/unittests/test_validation.py
@@ -286,12 +286,11 @@ class TestValidation:
     async def test_type_error(self, validator_func: ValidatorType, param_map: dict[str, str], expected_error: str):
         validator_set = ValidatorSet[DataSetTest]()
         validator_set.register(validator_func, param_map)
-        with pytest.raises(TypeError) as error:
+        with pytest.raises(ExceptionGroup) as error_group:
             await validator_set.validate(dataset_instance)
-        validator_set.register(check_multiple_registration, {"x": "x"})
-        validator_set.register(check_multiple_registration, {"x": "z.x"})
 
-        assert str(error.value) == expected_error
+        assert len(error_group.value.exceptions) == 1
+        assert expected_error in str(error_group.value.exceptions[0])
 
     async def test_timeout(self):
         validator_set = ValidatorSet[DataSetTest]()


### PR DESCRIPTION
The framework will produce error IDs which will be unique for each raise-statement across all validator functions.
More technical, it will corresond to the tuple of module name, function name and line in function. I.e. it will be also constant across python sessions iff this 3-tuple remains constant.