### PR TITLE
Introduce `ValidationSummary`

### DIFF
--- a/src/bomf/model/__init__.py
+++ b/src/bomf/model/__init__.py
@@ -79,3 +79,6 @@ class Bo4eDataSet(BaseModel, ABC):
                     f"You probably forgot to call super().__init__() in the constructor of {self.__class__}"
                 ) from attribute_error
             raise
+
+    def __hash__(self):
+        return hash(self.get_id())

--- a/src/bomf/validation/core.py
+++ b/src/bomf/validation/core.py
@@ -7,7 +7,6 @@ import inspect
 import itertools
 import logging
 import random
-import re
 import types
 from dataclasses import dataclass
 from datetime import timedelta
@@ -141,6 +140,7 @@ class ValidationError(RuntimeError):
         self.error_id = error_id
 
 
+# pylint: disable=too-many-instance-attributes
 class ValidationSummary:
     """
     This class provides some analysis of a validation process (`ValidatorSet.validate(*data_sets)`). It is read-only.
@@ -199,8 +199,7 @@ class ValidationSummary:
         """
         if hasattr(self, "_initialized"):
             raise AttributeError("This object is read-only.")
-        else:
-            super().__setattr__(key, value)
+        super().__setattr__(key, value)
 
     def __delattr__(self, item):
         """
@@ -209,6 +208,9 @@ class ValidationSummary:
         raise AttributeError("This object is read-only.")
 
     def summarize(self, with_errors_per_id: bool = True, indent: str = "", add_indent: str = "\t") -> str:
+        """
+        Returns a short string representation to give a minimal summary about the validation process.
+        """
         result = (
             f"{indent}{self.total} data sets, "
             f"{self.num_succeeds} succeeds, "

--- a/src/bomf/validation/core.py
+++ b/src/bomf/validation/core.py
@@ -614,7 +614,7 @@ class ValidatorSet(Generic[DataSetT]):
     async def validate(self, *data_sets: DataSetT) -> ValidationSummary:
         """
         Validates each of the provided data set instances onto the registered validator functions.
-        Any errors occurring during validation will be collected and raised together as ExceptionGroup.
+        Any errors occurring during validation will be collected and returned via a `ValidationSummary` object.
         If a validator depends on other validators which are raising errors, the execution of this validator will be
         abandoned.
         """
@@ -638,10 +638,5 @@ class ValidatorSet(Generic[DataSetT]):
                             coroutines,
                             error_handlers[data_set],
                         )
-            # if len(error_handlers[data_set].excs) > 0:
-            #     raise ExceptionGroup(
-            #         f"Validation errors for {data_set.__class__.__name__}(id={data_set.get_id()})",
-            #         list(error_handlers[data_set].excs.values()),
-            #     )
 
         return ValidationSummary(self, error_handlers)


### PR DESCRIPTION
The `validate` method no longer raises an `ExceptionGroup` on failures. Instead, everything is collected and returned as a `ValidationSummary` object. This object can than be used to check all sorts of things about the validation process.