### PR TITLE
📍Pin pydantic version to v1 in setup.cfg, too

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.10
 install_requires =
     attrs
     bo4e
-    pydantic
+    pydantic==1.*
     typeguard==2.13.3
 # because v4.x crashes: https://github.com/Hochfrequenz/bo4e_migration_framework/pull/70
     frozendict


### PR DESCRIPTION
this is the file relevant for downstream code using this package. requirements.in is for internal use