### PR TITLE
Make Error-ID generation more intuitive

### DIFF
--- a/src/bomf/validation/core/errors.py
+++ b/src/bomf/validation/core/errors.py
@@ -80,8 +80,11 @@ def _generate_new_id(identifier: _IdentifierType, last_id: Optional[_IDType] = N
         module_name_hash = int(hashlib.blake2s((identifier[0] + identifier[1]).encode(), digest_size=4).hexdigest(), 16)
         random.seed(module_name_hash)
     # This range has no further meaning, but you have to define it.
+    rand_range = (1_000_000, 9_998_999)
+    # This guarantees that functions with up to 1000 lines of code remain stable in their first digits if an error
+    # changes in its line number inside the function.
     error_id_range = (1_000_000, 9_999_999)
-    return (random.randint(*error_id_range) + identifier[2] - error_id_range[0]) % (
+    return (random.randint(*rand_range) + identifier[2] - error_id_range[0]) % (
         error_id_range[1] - error_id_range[0] + 1
     ) + error_id_range[0]
 

--- a/src/bomf/validation/core/errors.py
+++ b/src/bomf/validation/core/errors.py
@@ -78,9 +78,12 @@ def _generate_new_id(identifier: _IdentifierType, last_id: Optional[_IDType] = N
         random.seed(last_id)
     else:
         module_name_hash = int(hashlib.blake2s((identifier[0] + identifier[1]).encode(), digest_size=4).hexdigest(), 16)
-        random.seed(module_name_hash + identifier[2])
+        random.seed(module_name_hash)
     # This range has no further meaning, but you have to define it.
-    return random.randint(1_000_000, 9_999_999)
+    error_id_range = (1_000_000, 9_999_999)
+    return (random.randint(*error_id_range) + identifier[2] - error_id_range[0]) % (
+        error_id_range[1] - error_id_range[0] + 1
+    ) + error_id_range[0]
 
 
 def _get_error_id(identifier: _IdentifierType) -> _IDType:

--- a/unittests/test_validation.py
+++ b/unittests/test_validation.py
@@ -453,7 +453,7 @@ class TestValidation:
         )
         # This ensures that the ID is constant across python sessions - as long as the line number of the raising
         # exception in `check_fail` doesn't change.
-        assert sub_exceptions1[PathMappedValidator(validator_check_fail, {"x": "x"})].error_id == 1746866
+        assert sub_exceptions1[PathMappedValidator(validator_check_fail, {"x": "x"})].error_id == 8103059
 
     async def test_utility_required_and_optional(self):
         validation_manager = ValidationManager[DataSetTest]()


### PR DESCRIPTION
This PR makes the Error-ID more intuitive. If the line number of the thrown error changes e.g. when you edit a validation function this now mostly affects the last digits. This is, because now the line number of the error inside the function gets added to the randomly generated number instead of taking this into account for the seed.