### PR TITLE
⚡ Refactor `PydanticJsonFileEntityLoader` to _not_ use `json.dump` but `model_dump_json` instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,11 +20,11 @@ iso3166==2.1.1
     # via bo4e
 networkx==3.1
     # via -r requirements.in
-pydantic==2.1.1
+pydantic==2.2.0
     # via
     #   -r requirements.in
     #   bo4e
-pydantic-core==2.4.0
+pydantic-core==2.6.0
     # via pydantic
 pyhumps==3.8.0
     # via bo4e

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ pydantic-core==2.4.0
     # via pydantic
 pyhumps==3.8.0
     # via bo4e
-typeguard==4.1.0
+typeguard==4.1.1
     # via -r requirements.in
 typing-extensions==4.7.1
     # via

--- a/src/bomf/loader/entityloader.py
+++ b/src/bomf/loader/entityloader.py
@@ -164,7 +164,10 @@ class JsonFileEntityLoader(EntityLoader[_TargetEntity], Generic[_TargetEntity]):
         if not self._file_path.exists():
             return []
         with open(self._file_path, "r", encoding="utf-8") as json_file:
-            json_body = json.load(json_file)
+            file_body = json_file.read()
+            if not file_body:
+                return []
+            json_body = json.load(file_body)
         return json_body
 
     async def load_entity(self, entity: _TargetEntity) -> Optional[EntityLoadingResult]:

--- a/src/bomf/loader/entityloader.py
+++ b/src/bomf/loader/entityloader.py
@@ -206,9 +206,13 @@ class PydanticJsonFileEntityLoader(EntityLoader[_PydanticTargetModel], Generic[_
         self._file_lock = asyncio.Lock()
 
     def _load_entries_from_file_if_exist(self) -> _ListOfPydanticModels[_PydanticTargetModel]:
+        empty_list = _ListOfPydanticModels[_PydanticTargetModel].model_validate([])
         if not self._file_path.exists():
-            return _ListOfPydanticModels[_PydanticTargetModel].model_validate([])
+            return empty_list
         with open(self._file_path, "r", encoding="utf-8") as json_file:
+            file_body = json_file.read()
+            if not file_body:  # if the file exists but is empty
+                return empty_list
             json_body = _ListOfPydanticModels[_PydanticTargetModel].model_validate_json(json_file.read())
         return json_body
 

--- a/src/bomf/loader/entityloader.py
+++ b/src/bomf/loader/entityloader.py
@@ -185,7 +185,7 @@ class JsonFileEntityLoader(EntityLoader[_TargetEntity], Generic[_TargetEntity]):
 
 
 _PydanticTargetModel = TypeVar("_PydanticTargetModel")
-# This is _not_ bound to BaseModel because:
+# This is _not_ bound to BaseModel because of https://github.com/pydantic/pydantic/issues/7345
 
 
 # pylint:disable=too-few-public-methods

--- a/src/bomf/loader/entityloader.py
+++ b/src/bomf/loader/entityloader.py
@@ -167,7 +167,7 @@ class JsonFileEntityLoader(EntityLoader[_TargetEntity], Generic[_TargetEntity]):
             file_body = json_file.read()
             if not file_body:
                 return []
-            json_body = json.load(file_body)
+            json_body = json.loads(file_body)
         return json_body
 
     async def load_entity(self, entity: _TargetEntity) -> Optional[EntityLoadingResult]:

--- a/src/bomf/loader/entityloader.py
+++ b/src/bomf/loader/entityloader.py
@@ -213,7 +213,7 @@ class PydanticJsonFileEntityLoader(EntityLoader[_PydanticTargetModel], Generic[_
             file_body = json_file.read()
             if not file_body:  # if the file exists but is empty
                 return empty_list
-            json_body = _ListOfPydanticModels[_PydanticTargetModel].model_validate_json(json_file.read())
+            json_body = _ListOfPydanticModels[_PydanticTargetModel].model_validate_json(file_body)
         return json_body
 
     async def load_entity(self, entity: _PydanticTargetModel) -> Optional[EntityLoadingResult]:

--- a/src/bomf/loader/entityloader.py
+++ b/src/bomf/loader/entityloader.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Awaitable, Callable, Generic, Optional, TypeVar
 
 import attrs
-from pydantic import BaseModel, RootModel, SerializeAsAny  # pylint:disable=no-name-in-module
+from pydantic import RootModel, SerializeAsAny  # pylint:disable=no-name-in-module
 
 _TargetEntity = TypeVar("_TargetEntity")
 

--- a/unittests/test_entity_loader.py
+++ b/unittests/test_entity_loader.py
@@ -189,7 +189,7 @@ class TestPydanticJsonFileEntityLoader:
             with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as tmp_file:
                 json_file_path = Path(tmp_file.name)
                 assert json_file_path.exists()
-                json_file_loader = loader_class(json_file_path)
+                json_file_loader = loader_class(json_file_path)  # type:ignore[call-arg]
                 if load_multiple:
                     _ = await json_file_loader.load_entities([])
                 else:

--- a/unittests/test_entity_loader.py
+++ b/unittests/test_entity_loader.py
@@ -145,7 +145,7 @@ class TestPydanticJsonFileEntityLoader:
     @pytest.mark.parametrize(
         "loader_class", [pytest.param(MyPydanticOnlyLoader), pytest.param(LegacyPydanticJsonFileEntityLoader)]
     )
-    async def test_dumping_to_file(
+    async def test_dumping_to_file_via_load_entities(
         self, number_of_models: int, loader_class: Type[EntityLoader[MyPydanticClass]], tmp_path
     ):
         my_entities = [MyPydanticClass(foo="asd", bar=x) for x in range(number_of_models)]


### PR DESCRIPTION
A test is not a proper benchmark but at least for the code path using the plural `load_entities` this should result significantly speed up.

In the below test `MyPydanticOnlyLoader` uses the refactore `PydanticJsonFileEntityLoader` while `LegacyPydanticJsonFileEntityLoader` is basically the code of the `PydanticJsonFileEntityLoader` _before_ this pull request. The test indicates, that it should now be much faster than before.

![grafik](https://github.com/Hochfrequenz/bo4e_migration_framework/assets/23094997/4ee60cac-c9ed-451c-801b-7e512299c96e)


My guess is, that in the `load_entity` path in both cases the bottle neck is opening and closing the file over and over again.

I published this as v0.6.6c